### PR TITLE
Fix routing

### DIFF
--- a/app.js
+++ b/app.js
@@ -17,9 +17,6 @@ app.use(cors({
 }));
 
 // ルーティング先
-const indexRouter = require('./routes/index.js');
-app.use('/', indexRouter);
-
 const ProductsRouter = require('./routes/products/products.js');
 app.use('/api/products', ProductsRouter);
 
@@ -28,6 +25,9 @@ app.use('/api/vote', VoteRouter);
 
 const SettingsRouter = require('./routes/settings/setting.js');
 app.use('/api/settings', SettingsRouter);
+
+const indexRouter = require('./routes/index.js');
+app.use('/', indexRouter);
 
 // catch 404 and forward to error handler
 app.use(function(req, res, next) {

--- a/routes/index.js
+++ b/routes/index.js
@@ -1,9 +1,11 @@
 const express = require('express');
 const router = express.Router();
 
+const path = require("path");
+
 /* GET home page. */
-router.get('/', function(req, res) {
-    res.send('index.html');
+router.get('*', function(req, res) {
+    res.sendFile(path.join(__dirname,"../", "public", "index.html"));
 });
 
 module.exports = router;

--- a/routes/products/scheme.js
+++ b/routes/products/scheme.js
@@ -38,8 +38,8 @@ const scheme = {
                     ],
                     'products', 'photos', 'products.product_id', 
                     'photos.product_id', 'products.product_id', '?', 
-                    'photos.product_image', '0', 'photos.product_image', 
-                    '?'
+                    'photos.product_image', '?', 'photos.product_image', 
+                    '0'
 
                 ]
             },


### PR DESCRIPTION
express側で /api/* 以外の /以下にアクセスされた場合、ファイルとしてindex.htmlを返すように修正。
これにより、各ページでページをリロードした場合でも、index.html => app.js => react => react-routerの順でpathが解決され、正常に各ページが表示されることをローカルで確認。
また、存在しないpathの場合にはreact-router側で404にリダイレクトするため、404も正常に返却されることを確認。